### PR TITLE
issue/3305 Support for alternative course folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Add to Adapt framework ``package.json``
     }
 ```
 
+### Changing ``course`` folder name
+Add to Adapt framework ``package.json``
+```json
+    "grunt": {
+        "options": {
+            "coursedir": "alternative"
+        }
+    }
+```
+
 ### IMSMANIFEST.XML variable replacement
 ```
 @@course.title

--- a/commands/015clean.js
+++ b/commands/015clean.js
@@ -2,6 +2,7 @@ const commands = require('../globals/commands')
 const tasks = require('../globals/tasks')
 const { log } = require('../globals/logger')
 const { remove } = require('../globals/fs-globs')
+const adapt = require('../globals/adapt')
 
 commands.create({
 
@@ -45,11 +46,13 @@ commands.create({
     const namePrefix = name ? name + ': ' : ''
     log(`${namePrefix}Cleaning up...`)
 
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
+
     let globs
     if (paths.isServerBuild) {
       globs = [
-        '!course/**',
-        '!course',
+        `!${coursedir}/**`,
+        `!${coursedir}`,
         '**'
       ]
     } else {

--- a/commands/031jsonminify.js
+++ b/commands/031jsonminify.js
@@ -56,6 +56,7 @@ commands.create({
     const namePrefix = name ? name + ': ' : ''
 
     const jsonext = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.jsonext) || 'json'
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
 
     log(`${namePrefix}Minifying...`)
 
@@ -64,7 +65,7 @@ commands.create({
         '*.' + jsonext,
         '**/*.' + jsonext
       ],
-      location: path.join(paths.dest.location, 'course')
+      location: path.join(paths.dest.location, coursedir)
     })
     await async.forEachLimit(jsons, 1, stat => {
       let minified

--- a/commands/032jsonprettify.js
+++ b/commands/032jsonprettify.js
@@ -55,6 +55,7 @@ commands.create({
     const namePrefix = name ? name + ': ' : ''
 
     const jsonext = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.jsonext) || 'json'
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
 
     log(`${namePrefix}Prettifying...`)
 
@@ -63,7 +64,7 @@ commands.create({
         '*.' + jsonext,
         '**/*.' + jsonext
       ],
-      location: path.join(paths.dest.location, 'course')
+      location: path.join(paths.dest.location, coursedir)
     })
     if (!paths.isServerBuild) {
       // Ensure src files are 2 spaces to stop jumping around
@@ -72,7 +73,7 @@ commands.create({
           '*.' + jsonext,
           '**/*.' + jsonext
         ],
-        location: path.join(paths.src.location, 'course')
+        location: path.join(paths.src.location, coursedir)
       }))
     }
     return async.forEachLimit(jsons, 1, async (stat) => {

--- a/commands/046zipaat.js
+++ b/commands/046zipaat.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra')
 const ZipLibrary = require('node-native-zip-compression')
 const { stats } = require('../globals/fs-globs')
 const commands = require('../globals/commands')
+const adapt = require('../globals/adapt')
 const tasks = require('../globals/tasks')
 const { log, warn } = require('../globals/logger')
 
@@ -50,10 +51,12 @@ commands.create({
     const outputDir = path.join(process.cwd(), 'zips')
     await fs.mkdirp(outputDir)
 
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
+
     const files = await stats({
       globs: [
-        paths.isServerBuild && `${paths.dest.relative}/course/**`,
-        paths.isServerBuild && `!src/course/**`,
+        paths.isServerBuild && `${paths.dest.relative}/${coursedir}/**`,
+        paths.isServerBuild && `!src/${coursedir}/**`,
         '!.git',
         '!src/*.js',
         '!*.zip',
@@ -67,8 +70,8 @@ commands.create({
     return new Promise((resolve, reject) => {
       const archive = new ZipLibrary()
       const zipFiles = files.map(stat => {
-        const mapToName = paths.isServerBuild && stat.relative.startsWith(`${paths.dest.relative}/course/`)
-          ? stat.relative.replace(new RegExp(`^${paths.dest.relative}/course/`), 'src/course/')
+        const mapToName = paths.isServerBuild && stat.relative.startsWith(`${paths.dest.relative}/${coursedir}/`)
+          ? stat.relative.replace(new RegExp(`^${paths.dest.relative}/${coursedir}/`), `src/${coursedir}/`)
           : stat.relative
         return {
           name: mapToName,

--- a/commands/047redundantassets.js
+++ b/commands/047redundantassets.js
@@ -51,11 +51,12 @@ commands.create({
     let fileAssetListPaths = []
 
     const jsonext = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.jsonext) || 'json'
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
 
     const jsons = await stats({
       globs: [
-        'course/*.' + jsonext,
-        'course/**/*.' + jsonext
+        `${coursedir}/*.${jsonext}`,
+        `${coursedir}/**/*.%{jsonext}`
       ],
       location: paths.dest.location,
       dirs: false
@@ -170,8 +171,8 @@ commands.create({
         '!adapt/css/assets/**',
         'assets/**/*.+(png|gif|jpg|jpeg|mp4|ogv|mp3|ogg|pdf|svg|vtt|pdf)',
         'assets/*.+(png|gif|jpg|jpeg|mp4|ogv|mp3|ogg|pdf|svg|vtt|pdf)',
-        'course/**/*.+(png|gif|jpg|jpeg|mp4|ogv|mp3|ogg|pdf|svg|vtt|pdf)',
-        'course/*.+(png|gif|jpg|jpeg|mp4|ogv|mp3|ogg|pdf|svg|vtt|pdf)'
+        `${coursedir}/**/*.+(png|gif|jpg|jpeg|mp4|ogv|mp3|ogg|pdf|svg|vtt|pdf)`,
+        `${coursedir}/*.+(png|gif|jpg|jpeg|mp4|ogv|mp3|ogg|pdf|svg|vtt|pdf)`
       ],
       location: paths.dest.location,
       dirs: false

--- a/commands/050watch.js
+++ b/commands/050watch.js
@@ -3,6 +3,7 @@ const commands = require('../globals/commands')
 const fsg = require('../globals/fs-globs')
 const tasks = require('../globals/tasks')
 const { log, notice } = require('../globals/logger')
+const adapt = require('../globals/adapt')
 
 commands.create({
 
@@ -47,6 +48,7 @@ commands.create({
   _allLayouts: false,
 
   async perform (name, options, paths) {
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
     tasks.isWaiting = true
 
     if (paths.isServerBuild && !this._watchPaths['course:' + name]) {
@@ -54,7 +56,7 @@ commands.create({
       this._clearWatchPaths['course:' + name] =
       await fsg.watch({
         globs: [
-          'course/**'
+          `${coursedir}/**`
         ],
         location: paths.dest.location
       }, (changes) => {
@@ -76,18 +78,18 @@ commands.create({
         }
         this.performTasks()
       })
-    } else if (!paths.isServerBuild && !this._watchPaths['src/course']) {
-      this._watchPaths['src/course'] =
-      this._clearWatchPaths['src/course'] =
+    } else if (!paths.isServerBuild && !this._watchPaths[`src/${coursedir}`]) {
+      this._watchPaths[`src/${coursedir}`] =
+      this._clearWatchPaths[`src/${coursedir}`] =
       await fsg.watch({
         globs: [
-          'course/**'
+          `${coursedir}/**`
         ],
         location: paths.src.location
       }, (changes) => {
         if (this._allLayouts) return
-        if (this._changedLayouts['src/course']) return
-        this._changedLayouts['src/course'] = paths
+        if (this._changedLayouts[`src/${coursedir}`]) return
+        this._changedLayouts[`src/${coursedir}`] = paths
 
         const changeTypes = changes.map(item => item.change)
         const wasAnythingAddedOrDeleted = (changeTypes.includes('added') || changeTypes.includes('deleted'))
@@ -121,7 +123,7 @@ commands.create({
           'core/less/*',
           'core/templates/**/*',
           'core/templates/*',
-          '!course'
+          `!${coursedir}`
         ],
         location: paths.src.location
       }, (changes) => {
@@ -168,7 +170,7 @@ commands.create({
           'core/scripts/*',
           'core/fonts/**/*',
           'core/fonts/*',
-          '!course'
+          `!${coursedir}`
         ],
         location: paths.src.location
       }, (changes) => {

--- a/commands/081translateimport.js
+++ b/commands/081translateimport.js
@@ -4,6 +4,7 @@ const grunt = require('../globals/grunt')
 const commands = require('../globals/commands')
 const tasks = require('../globals/tasks')
 const { log } = require('../globals/logger')
+const adapt = require('../globals/adapt')
 
 commands.create({
 
@@ -38,6 +39,7 @@ commands.create({
   },
 
   perform (name, options, paths) {
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
     const isVerbose = commands.has('verbose') || commands.switches(['v']) ||
     commands.options(['verbose'])
 
@@ -58,9 +60,9 @@ commands.create({
 
     if (paths.isServerBuild) {
       gruntOpts.outputdir = paths.dest.location
-      fs.mkdirpSync(path.join(gruntOpts.outputdir, 'course', targetLang))
+      fs.mkdirpSync(path.join(gruntOpts.outputdir, coursedir, targetLang))
     } else {
-      fs.mkdirpSync(path.join('src/course', targetLang))
+      fs.mkdirpSync(path.join(`src/${coursedir}`, targetLang))
     }
 
     const namePrefix = name ? name + ': ' : ''

--- a/globals/layouts.js
+++ b/globals/layouts.js
@@ -2,24 +2,26 @@ const path = require('path')
 const fs = require('fs-extra')
 const fsg = require('../globals/fs-globs')
 const async = require('async')
+const adapt = require('../globals/adapt')
 
 class Layouts {
   static load () {
+    const coursedir = (adapt && adapt.grunt && adapt.grunt.options && adapt.grunt.options.coursedir) || 'course'
     return new Promise((resolve) => {
       resolve({
         'builds': fs.existsSync(path.join(process.cwd(), 'builds')),
-        'src/course': fs.existsSync(path.join(process.cwd(), 'src/course'))
+        [`src/${coursedir}`]: fs.existsSync(path.join(process.cwd(), `src/${coursedir}`))
       })
     }).then(async (layout) => {
-      if (layout['src/course']) {
+      if (layout[`src/${coursedir}`]) {
         fs.mkdirpSync(path.join(process.cwd(), 'build'))
-        layout['src/course'] = {
+        layout[`src/${coursedir}`] = {
           dest: await fsg.stat(path.join(process.cwd(), 'build')),
           src: await fsg.stat(path.join(process.cwd(), 'src')),
           isServerBuild: false
         }
       } else {
-        delete layout['src/course']
+        delete layout[`src/${coursedir}`]
       }
 
       const hasBuilds = !!(layout.builds)
@@ -31,7 +33,7 @@ class Layouts {
 
       // collect all builds immediate subfolders, attach to layout.builds[]
       const buildsPath = path.join(process.cwd(), 'builds')
-      const stats = await fsg.stats({ globs: '**/course/config.*', location: buildsPath })
+      const stats = await fsg.stats({ globs: `**/${coursedir}/config.*`, location: buildsPath })
       await async.forEachOfLimit(stats, 1, async (stat) => {
         const moduleName = path.join(stat.dir, '..')
         const moduleDirStat = await fsg.stat(path.join(buildsPath, moduleName), process.cwd())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rub-cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rub-cli",
   "commonName": "rub-cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "custom": false,
   "description": "Adapt Buildkit (rub-cli)",
   "failText": "Please run: 'npm install -g rub-cli'",


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3305

### Added
* Support for alternative course folder name through the `package.json` grunt config options

### Testing
1. Install rub beta with `npm install -g rub-cli@beta`
2. Download the framework, core and plugins, switching to the correct branches
```sh
git clone https://github.com/adaptlearning/adapt_framework 3305-course
cd 3305-course
git checkout issue/3305
adapt devinstall && npm install
cd src/core
git checkout issue/3305
cd ../../
```
3. Move the src/course folder into builds/m05/alternative
4. Add the following to the package.json:
```json
"grunt": {
  "options": {
    "coursedir": "alternative"
  }
}
```
4. Find and replace all of the images in the json files from `course/` to `alternative/`