### PR TITLE
Update: Improve error color visibility in output (fixes #72)

### DIFF
--- a/globals/grunt.js
+++ b/globals/grunt.js
@@ -3,7 +3,8 @@ const path = require('path')
 const pwd = process.cwd()
 const adapt = require('../globals/adapt')
 const patch = require('../globals/patch')
-const { pad, log, notice } = require('../globals/logger')
+const chalk = require('chalk')
+const { pad, log, notice, warn } = require('../globals/logger')
 
 class Grunt {
   static run (name, tasks, options) {
@@ -99,7 +100,18 @@ class Grunt {
     let stderr = Grunt.parseOutput(data.stderr)
     if (stdout.includes(stderr)) stderr = '';
     if (!stdout && !stderr) return
-    if (stdout) notice(data.name + stdout)
+    if (stdout) {
+      const lines = stdout.split('\n').filter(Boolean)
+      const hasFatal = lines.some(line => line.startsWith('Fatal error'))
+      if (hasFatal) {
+        lines.forEach(line => line.startsWith('Fatal error') ? warn(line) : notice(line))
+      } else {
+        notice(data.name)
+        pad(6)
+        lines.forEach(line => line.startsWith('Warning:') ? (pad(4), warn(line), pad(6)) : warn(`${chalk.green('>>')} ${chalk.yellow(line)}`))
+        pad(4)
+      }
+    }
     if (stderr) log(stderr)
     pad(2)
   }


### PR DESCRIPTION
Fixes #72

### Update
* Error output from `Grunt.error()` now renders in red with green `>>` bullets, matching grunt's own error formatting
* Fatal errors are highlighted entirely in red
* `Warning:` lines are rendered in red at the task-name indent level
* Regular error lines render as `>> message` with a green bullet and yellow text

### Testing
1. Introduce a deliberate ID mismatch in course JSON (e.g. give a block a `_parentId` that doesn't exist)
2. Run `rub -b` or `rub`
3. Confirm ID validation errors now appear in red with `>>` bullet formatting
4. Fix the JSON — confirm the red messages disappear

### Screenshot
![Screenshot 2026-03-18 at 3 58 33 PM](https://github.com/user-attachments/assets/d33fd9b3-f25b-4e13-8078-55dad468e2f5)
